### PR TITLE
Integrate Koin for dependency injection and Navigation 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Sample Android Posts App
+
+An open-source **Android Kotlin Jetpack Compose** sample that demonstrates how to build a modern posts feed backed by a REST API. The project showcases **Navigation 3**, **Koin dependency injection**, **Retrofit/OkHttp networking**, and a clean UI layer powered by **Material 3**. Clone it, run it, and ⭐️ star it if it inspires your next app!
+
+## Table of Contents
+- [Highlights](#highlights)
+- [Architecture Overview](#architecture-overview)
+- [Tech Stack](#tech-stack)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
+- [Local API Notes](#local-api-notes)
+- [Roadmap Ideas](#roadmap-ideas)
+- [Contributing](#contributing)
+
+## Highlights
+- 100% Kotlin with Jetpack Compose UI and Material 3 theming.
+- Navigation orchestrated by the new Navigation 3 back stack with custom nav keys.
+- Reactive UI fed by coroutines and immutable state collections.
+- Koin modules wire up Retrofit, repositories, and ViewModels for quick DI bootstrapping.
+- Retrofit + OkHttp + Gson deliver a simple, testable networking stack hitting `http://10.0.2.2:3000/posts` in the Android emulator.
+- Modern Gradle setup (Kotlin DSL, version catalogs) ready for experimentation or production hardening.
+
+## Architecture Overview
+```
+ApplicationPosts (starts Koin) ──> Koin Modules (network, repository, viewModel)
+          │
+          ├─> RetrofitClient (base networking layer)
+          ├─> PostRepository (data access + mapping)
+          └─> PostViewModel (state holder using coroutines)
+                         │
+                         └─> Compose UI (PostsMain ➜ PostsList ➜ PostDetail)
+```
+
+- **State Management:** `PostViewModel` exposes Compose-friendly state via `mutableStateListOf`, cleared and filled on each fetch.
+- **Navigation:** `NavigationRoot` drives a back stack of `Screen` nav keys (`PostsList`, `PostDetail`), keeping state with Navigation 3 decorators.
+- **UI Layer:** `PostsMain` consumes the ViewModel using `koinViewModel()` and renders list/detail composables with Material 3 components.
+
+## Tech Stack
+- Kotlin 2.1.10
+- Jetpack Compose + Material 3
+- Navigation 3 (runtime, UI, lifecycle ViewModel integration)
+- Koin 3.5.6 for dependency injection (android + compose extensions)
+- Retrofit 3 + OkHttp 5.1 with Gson converter
+- Kotlinx Serialization (used for navigation key persistence)
+- Coroutines + ViewModel scope
+
+## Project Structure
+```
+app/
+ ├─ src/main/java/com/hassanjamil/sampleandroidpostsapp
+ │   ├─ ApplicationPosts.kt          # Koin bootstrap
+ │   ├─ navigation/                  # NavigationRoot + Screen nav keys
+ │   ├─ features/posts/              # Feature module
+ │   │   ├─ data/                    # Repository + models
+ │   │   └─ ui/                      # Compose screens + ViewModel
+ │   └─ di/                          # Koin modules (network, repository, viewModel)
+ └─ ...
+```
+
+## Getting Started
+1. **Clone** the repository:
+   ```bash
+   git clone https://github.com/hassaanjamil/SampleAndroidPostsApp.git
+   cd SampleAndroidPostsApp
+   ```
+2. **Start the local API** (any JSON server returning posts at `http://localhost:3000/posts`). When running on the Android emulator, this becomes `http://10.0.2.2:3000/posts`.
+3. **Sync & Build** inside Android Studio (Giraffe+), or from the CLI:
+   ```bash
+   ./gradlew assembleDebug
+   ```
+4. **Run** the app on an emulator or device. Tap a card to view post details inside the Compose navigation flow.
+
+### Requirements
+- Android Studio Koala / latest stable tooling
+- Android Gradle Plugin 8.10.0-beta01 or newer
+- JDK 11+
+
+## Local API Notes
+- The sample expects a CRUD endpoint returning Post objects (`id`, `title`, `body`, `userId`).
+- Need instant mock data? Spin up a JSON Server:
+  ```bash
+  npx json-server --watch db.json --port 3000
+  ```
+  with a `db.json` shaped like:
+  ```json
+  {
+    "posts": [
+      { "id": 1, "title": "Compose Rocks", "body": "Declarative UI on Android.", "userId": 1 }
+    ]
+  }
+  ```
+
+## Roadmap Ideas
+- Offline caching with Room and Koin scopes.
+- UI tests using Compose Testing APIs.
+- Post creation/edit flows leveraging Navigation 3 scenes.
+- Theme switching + responsive layouts with Material 3 adaptive libraries.
+
+## Contributing
+Pull requests, issues, and ideas for new features are always welcome. If this **Android Jetpack Compose + Koin retrofit sample** helps your project or saved you some time, please:
+
+1. ⭐️ **Star the repo** to support continued development.
+2. Share it with fellow Android developers exploring modern toolchains.
+
+Happy coding!

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,8 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.google.dagger.hilt.android)
-    alias(libs.plugins.jetbrains.kotlin.kapt)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
 }
 
 android {
@@ -52,15 +51,27 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
 
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.google.dagger.hilt.android)
-    kapt(libs.google.dagger.hilt.android.compiler)
+    // kotlinx serialization
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.core)
 
+    // Navigation 3
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.nav3)
+    implementation(libs.androidx.material3.adaptive)
+
+    // Koin
+    implementation(libs.koin.android)
+    implementation(libs.koin.androidx.compose)
+
+    // Retrofit
     implementation(libs.squareup.retrofit2)
     implementation(libs.squareup.retrofit2.converter.gson)
     implementation(libs.squareup.okhttp3)
     implementation(libs.squareup.okhttp3.logging.interceptor)
 
+    // Test
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/ApplicationPosts.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/ApplicationPosts.kt
@@ -1,7 +1,27 @@
 package com.hassanjamil.sampleandroidpostsapp
 
 import android.app.Application
-import dagger.hilt.android.HiltAndroidApp
+import com.hassanjamil.sampleandroidpostsapp.di.networkModule
+import com.hassanjamil.sampleandroidpostsapp.di.repositoryModule
+import com.hassanjamil.sampleandroidpostsapp.di.viewModelModule
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.context.startKoin
+import org.koin.core.logger.Level
 
-@HiltAndroidApp
-class ApplicationPosts : Application()
+class ApplicationPosts : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        startKoin {
+            androidLogger(Level.ERROR)
+            androidContext(this@ApplicationPosts)
+            modules(
+                networkModule,
+                repositoryModule,
+                viewModelModule
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/MainActivity.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/MainActivity.kt
@@ -4,57 +4,18 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.hassanjamil.sampleandroidpostsapp.features.posts.ui.PostViewModel
-import com.hassanjamil.sampleandroidpostsapp.features.posts.ui.PostsList
+import com.hassanjamil.sampleandroidpostsapp.navigation.NavigationRoot
 import com.hassanjamil.sampleandroidpostsapp.ui.theme.SampleAndroidPostsAppTheme
-import dagger.hilt.android.AndroidEntryPoint
 
-@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
-    private val postsViewModel: PostViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             SampleAndroidPostsAppTheme(dynamicColor = false) {
-                val posts = postsViewModel.posts
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    PostsList(
-                        modifier = Modifier
-                            .padding(innerPadding)
-                            .fillMaxSize(),
-                        itemModifier = Modifier.fillMaxWidth(),
-                        posts = posts
-                    )
-                }
+                NavigationRoot()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    SampleAndroidPostsAppTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/di/NetworkModule.kt
@@ -2,25 +2,10 @@ package com.hassanjamil.sampleandroidpostsapp.di
 
 import com.hassanjamil.sampleandroidpostsapp.service.ApiService
 import com.hassanjamil.sampleandroidpostsapp.service.RetrofitClient
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import org.koin.dsl.module
 import retrofit2.Retrofit
-import javax.inject.Singleton
 
-@Module
-@InstallIn(SingletonComponent::class)
-object NetworkModule {
-    @Provides
-    @Singleton
-    fun provideRetrofit(): Retrofit {
-        return RetrofitClient.retrofit
-    }
-
-    @Provides
-    @Singleton
-    fun provideApiService(retrofit: Retrofit): ApiService {
-        return retrofit.create(ApiService::class.java)
-    }
+val networkModule = module {
+    single<Retrofit> { RetrofitClient.retrofit }
+    single<ApiService> { get<Retrofit>().create(ApiService::class.java) }
 }

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/di/RepositoryModule.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/di/RepositoryModule.kt
@@ -2,20 +2,8 @@ package com.hassanjamil.sampleandroidpostsapp.di
 
 import com.hassanjamil.sampleandroidpostsapp.features.posts.data.PostRepository
 import com.hassanjamil.sampleandroidpostsapp.features.posts.data.PostRepositoryImpl
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import org.koin.dsl.module
 
-@Module
-@InstallIn(SingletonComponent::class)
-@Suppress("unused")
-abstract class RepositoryModule {
-
-    @Binds
-    @Singleton
-    abstract fun bindMyRepository(
-        myRepositoryImpl: PostRepositoryImpl
-    ): PostRepository
+val repositoryModule = module {
+    single<PostRepository> { PostRepositoryImpl(get()) }
 }

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/di/ViewModelModule.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/di/ViewModelModule.kt
@@ -1,0 +1,9 @@
+package com.hassanjamil.sampleandroidpostsapp.di
+
+import com.hassanjamil.sampleandroidpostsapp.features.posts.ui.viewModels.PostViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+
+val viewModelModule = module {
+    viewModel { PostViewModel(get()) }
+}

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/PostRepository.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/PostRepository.kt
@@ -1,6 +1,6 @@
 package com.hassanjamil.sampleandroidpostsapp.features.posts.data
 
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.Post
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
 
 interface PostRepository {
     suspend fun getPosts(): List<Post>

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/PostRepositoryImpl.kt
@@ -1,10 +1,9 @@
 package com.hassanjamil.sampleandroidpostsapp.features.posts.data
 
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.Post
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
 import com.hassanjamil.sampleandroidpostsapp.service.ApiService
-import javax.inject.Inject
 
-class PostRepositoryImpl @Inject constructor(private val apiService: ApiService): PostRepository {
+class PostRepositoryImpl(private val apiService: ApiService) : PostRepository {
     override suspend fun getPosts(): List<Post> {
         return apiService.getPosts()
     }

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/model/Post.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/model/Post.kt
@@ -1,0 +1,11 @@
+package com.hassanjamil.sampleandroidpostsapp.features.posts.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Post(
+    val id: Int? = null,
+    val title: String? = null,
+    val body: String? = null,
+    val userId: Int? = null,
+)

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/model/User.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/model/User.kt
@@ -1,0 +1,10 @@
+package com.hassanjamil.sampleandroidpostsapp.features.posts.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class User(
+    val id: Int? = null,
+    val username: String? = null,
+    val name: String? = null
+)

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/serializables/Post.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/serializables/Post.kt
@@ -1,8 +1,0 @@
-package com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables
-
-data class Post(
-    val id: Int,
-    val title: String? = null,
-    val body: String? = null,
-    val userId: Int? = null,
-)

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/serializables/User.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/data/serializables/User.kt
@@ -1,7 +1,0 @@
-package com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables
-
-data class User(
-    val id: Int,
-    val username: String? = null,
-    val name: String? = null
-)

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/Home.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/Home.kt
@@ -1,0 +1,31 @@
+package com.hassanjamil.sampleandroidpostsapp.features.posts.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
+import com.hassanjamil.sampleandroidpostsapp.features.posts.ui.viewModels.PostViewModel
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun PostsMain(
+    modifier: Modifier = Modifier,
+    onPostClick: (Post) -> Unit
+) {
+    val postViewModel: PostViewModel = koinViewModel()
+    val posts = postViewModel.posts
+
+    Scaffold(modifier = modifier) { innerPadding ->
+        PostsList(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            itemModifier = Modifier.fillMaxWidth(),
+            posts = posts,
+            onPostClick = onPostClick
+        )
+    }
+}

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/PostDetail.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/PostDetail.kt
@@ -1,0 +1,46 @@
+package com.hassanjamil.sampleandroidpostsapp.features.posts.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
+
+@Composable
+fun PostDetail(
+    modifier: Modifier = Modifier,
+    post: Post
+) {
+    ElevatedCard(modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            val title = post.title?.takeIf { it.isNotBlank() }
+                ?: post.id?.let { "Post #$it" }
+                ?: "Post"
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = post.body?.takeIf { it.isNotBlank() } ?: "No description available.",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = post.userId?.takeIf { it > 0 }?.toString() ?: "User id not available",
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/PostListItem.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/PostListItem.kt
@@ -1,5 +1,6 @@
 package com.hassanjamil.sampleandroidpostsapp.features.posts.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,19 +12,23 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.Post
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
 
 
 @Composable
-fun PostItem(modifier: Modifier, post: Post) {
-    ElevatedCard(modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+fun PostListItem(modifier: Modifier, post: Post, onPostClick: (Post) -> Unit) {
+    ElevatedCard(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp)
+                .clickable { onPostClick(post) }
         ) {
             val title = post.title?.takeIf { it.isNotBlank() }
-                ?: post.id.let { "Post #$it" }
+                ?: post.id?.let { "Post #$it" }
+                ?: "Post"
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleMedium

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/PostsList.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/PostsList.kt
@@ -4,20 +4,25 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.Post
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
 
 @Composable
 fun PostsList(
     modifier: Modifier = Modifier,
     itemModifier: Modifier = Modifier,
-    posts: List<Post>
+    posts: List<Post>,
+    onPostClick: (Post) -> Unit,
 ) {
     LazyColumn(modifier = modifier) {
         items(
             items = posts,
-            key = { post -> post.id }
+            key = { post -> post.id ?: post.hashCode() }
         ) { post ->
-            PostItem(modifier = itemModifier, post = post)
+            PostListItem(
+                modifier = itemModifier,
+                post = post,
+                onPostClick = onPostClick
+            )
         }
     }
 }

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/viewModels/PostViewModel.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/features/posts/ui/viewModels/PostViewModel.kt
@@ -1,21 +1,15 @@
-package com.hassanjamil.sampleandroidpostsapp.features.posts.ui
+package com.hassanjamil.sampleandroidpostsapp.features.posts.ui.viewModels
 
-import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.Post
 import com.hassanjamil.sampleandroidpostsapp.features.posts.data.PostRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class PostViewModel @Inject constructor(
-    @Suppress("unused") private val _savedStateHandle: SavedStateHandle,
+class PostViewModel(
     private val repository: PostRepository
-): ViewModel() {
+) : ViewModel() {
     private val _posts = mutableStateListOf<Post>()
     val posts: List<Post> get() = _posts
 
@@ -24,13 +18,11 @@ class PostViewModel @Inject constructor(
     }
 
     fun fetchPosts() {
-//        return repository.getPosts();
         viewModelScope.launch {
             try {
                 val fetchedPosts = repository.getPosts()
                 _posts.clear()
                 _posts.addAll(fetchedPosts)
-                Log.d("POSTS", "Posts fetched successfully " + fetchedPosts.size)
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/navigation/NavigationRoot.kt
@@ -1,0 +1,38 @@
+package com.hassanjamil.sampleandroidpostsapp.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
+import androidx.navigation3.scene.rememberSceneSetupNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.hassanjamil.sampleandroidpostsapp.features.posts.ui.PostDetail
+import com.hassanjamil.sampleandroidpostsapp.features.posts.ui.PostsMain
+import com.hassanjamil.sampleandroidpostsapp.navigation.Screen.PostDetail as PostDetailScreen
+
+@Composable
+fun NavigationRoot() {
+    val backStack = rememberNavBackStack(Screen.Home)
+    NavDisplay(
+        backStack = backStack,
+        onBack = { backStack.removeLastOrNull() },
+        entryDecorators = listOf(
+            rememberSavedStateNavEntryDecorator(),
+            rememberViewModelStoreNavEntryDecorator(),
+            rememberSceneSetupNavEntryDecorator()
+        ),
+        entryProvider = { key ->
+            when (key) {
+                is Screen.Home -> NavEntry(key) {
+                    PostsMain(onPostClick = { post ->
+                        backStack.add(PostDetailScreen(post))
+                    })
+                }
+                is PostDetailScreen -> NavEntry(key) {
+                    PostDetail(post = key.post)
+                }
+                else -> error("Unknown NavKey: $key")
+            }
+        })
+}

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/navigation/Screen.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/navigation/Screen.kt
@@ -1,0 +1,16 @@
+package com.hassanjamil.sampleandroidpostsapp.navigation
+
+import androidx.navigation3.runtime.NavKey
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class Screen : NavKey {
+    @Serializable
+    data object Home : Screen()
+
+    @Serializable
+    data class PostDetail(
+        val post: Post
+    ) : Screen()
+}

--- a/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/service/ApiService.kt
+++ b/app/src/main/java/com/hassanjamil/sampleandroidpostsapp/service/ApiService.kt
@@ -1,7 +1,7 @@
 package com.hassanjamil.sampleandroidpostsapp.service
 
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.Post
-import com.hassanjamil.sampleandroidpostsapp.features.posts.data.serializables.User
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.Post
+import com.hassanjamil.sampleandroidpostsapp.features.posts.data.model.User
 import retrofit2.http.GET
 import retrofit2.http.Path
 @Suppress("unused")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,4 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    alias(libs.plugins.google.dagger.hilt.android) apply false
-    alias(libs.plugins.jetbrains.kotlin.kapt) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,9 +9,11 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
 composeBom = "2025.09.01"
-nav_version = "2.9.5"
-kapt = "1.8.0"
-hilt = "2.57.1"
+kotlinxSerialization = "1.9.0"
+nav3Core = "1.0.0-alpha10"
+nav3Lifecycle = "1.0.0-alpha04"
+material3Adaptive = "1.2.0-beta03"
+koin = "3.5.6"
 retrofit = "3.0.0"
 okhttp3 = "5.1.0"
 
@@ -30,10 +32,17 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "nav_version" }
-google-dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-google-dagger-hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
-
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-json= { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization"}
+# Core Navigation 3 libraries
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
+androidx-lifecycle-viewmodel-nav3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "nav3Lifecycle" }
+androidx-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "material3Adaptive" }
+# Koin
+koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
+koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
+# Retrofit, Okhttp
 squareup-retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 squareup-retrofit2-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 squareup-okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp3" }
@@ -43,6 +52,4 @@ squareup-okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version.re
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-google-dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-jetbrains-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kapt" }
-
+jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinxSerialization" }


### PR DESCRIPTION
This commit replaces Dagger Hilt with Koin for dependency management and introduces Navigation 3 for screen transitions.

Key changes include:
- Removed Dagger Hilt dependencies and configurations.
- Added and configured Koin dependencies (`koin-android`, `koin-androidx-compose`).
- Converted Hilt modules and annotations to Koin(`networkModule`, `repositoryModule`, `viewModelModule`) to provide dependencies.
- Added Navigation 3 dependencies and `kotlinx-serialization` for argument passing.
- Implemented `NavigationRoot` composable to manage app navigation using Navigation 3.
- Created `Screen` sealed class for navigation destinations.
- Introduced `PostsMain` composable to display the list of posts and handle navigation to post details.
- Added `PostDetail` composable to display individual post details.
- Updated `PostsList` and `PostListItem` to handle post click events for navigation.
- Renamed `PostItem.kt` to `PostListItem.kt`.
- Moved `PostViewModel.kt` to `features/posts/ui/viewModels` package.
- Renamed `serializables` package to `model` for data classes (`Post`, `User`) and added `@Serializable` annotation.
- Updated `MainActivity` to use `NavigationRoot` for its content.